### PR TITLE
add rinkeby config

### DIFF
--- a/config/rinkeby.json
+++ b/config/rinkeby.json
@@ -1,0 +1,4 @@
+{
+  "network": "rinkeby",
+  "factory": {"addr": "0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B", "birthBlock": 5590757}
+}


### PR DESCRIPTION
Hey! 👋 

I was trying to deploy this on `rinkeby`, but can't seem to get it to work.
Any clues on why this would work on `ropsten` but fail on `rinkeby`?

Broken `rinkeby` deployment:
https://thegraph.com/explorer/subgraph/rudolfs/test
https://thegraph.com/explorer/subgraph/radicle-dev/gnosis-safe-rinkeby

Working `ropsten` deployment:
https://thegraph.com/explorer/subgraph/rudolfs/test-ropsten
https://thegraph.com/explorer/subgraph/radicle-dev/gnosis-safe-ropsten
https://thegraph.com/explorer/subgraph/gjeanmart/gnosis-safe-ropsten

Some log excerpts from a failing index:
```
14/05/2021, 21:45:49 ERROR Subgraph instance failed to run: Transport error: Unexpected response status code: 400 Bad Request, code: SubgraphSyncingFailure

14/05/2021, 21:45:49 DEBUG Subgraph stopped, WASM runtime thread terminated

14/05/2021, 21:45:49 DEBUG Subgraph stopped, WASM runtime thread terminated, block_hash: 0x293c90640dc095424e6b125fefaad9ca3ab3f1cffa79a62628b831097e1c55c3, block_number: 8571732

14/05/2021, 21:45:49 DEBUG Error querying traces error = Err(Transport error: Unexpected response status code: 400 Bad Request) from = 8571732 to = 8571732, block_hash: 0x293c90640dc095424e6b125fefaad9ca3ab3f1cffa79a62628b831097e1c55c3, block_number: 8571732

14/05/2021, 21:45:49 WARNING Trying again after trace_filter RPC call failed (attempt #10) with result Err(Transport error: Unexpected response status code: 400 Bad Request), block_hash: 0x293c90640dc095424e6b125fefaad9ca3ab3f1cffa79a62628b831097e1c55c3, block_number: 8571732

14/05/2021, 21:45:49 DEBUG Error querying traces error = Err(Transport error: Unexpected response status code: 400 Bad Request) from = 8571732 to = 8571732, block_hash: 0x293c90640dc095424e6b125fefaad9ca3ab3f1cffa79a62628b831097e1c55c3, block_number: 8571732
```